### PR TITLE
Drop lein-jdk-tools and shell out to java instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Use Leiningen to build the javadoc for the java source code in your projects.
 
 ## Usage
 
-Put `[lein-javadoc "0.1.1"]` into the `:plugins` vector of your project.clj.
+Put `[lein-javadoc "0.2.0"]` into the `:plugins` vector of your project.clj.
 
 For this plugin to do anything, you need to add a map of configuration
 options to the `:javadoc-opts` key of your project map (or a profile
@@ -42,6 +42,9 @@ if you prefer). The map can have the following keys:
   also be warned, to head off potential frustration. This option
   exists as a safety valve, in case this task does not currently
   support some combination of configuration options you really need.
+- `:tools-jar-paths`: This key is a vector of strings pointing to
+  possible locations of tools.jar. If empty or missing, lein-javadoc
+  will attempt to locate tools.jar by looking in java.home.
 
 Also note that you must have the JDK installed for this task to work,
 as Javadoc is a part of the JDK's lib/tools.jar. This plugin should
@@ -64,5 +67,9 @@ middleware required to work in its own project directory.
 ## License
 
 Copyright © 2013 David Santiago
+
+Other contributors:
+
+- Tim McCormack
 
 Distributed under the Eclipse Public License, the same as Clojure.

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,6 @@
-(defproject lein-javadoc "0.1.1"
+(defproject lein-javadoc "0.2.0-SNAPSHOT"
   :description "Run javadoc for the java source in your lein project."
   :url "http://github.com/davidsantiago/lein-javadoc"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :eval-in-leiningen true
-
-  :dependencies [[lein-jdk-tools "0.1.1"]])
+  :eval-in-leiningen true)

--- a/src/lein_javadoc/plugin.clj
+++ b/src/lein_javadoc/plugin.clj
@@ -1,7 +1,0 @@
-(ns lein-javadoc.plugin
-  (:require [lein-jdk-tools.plugin :as jdk-tools]))
-
-;; This just applies the lein-jdk-tools middleware automatically.
-(defn middleware
-  [project]
-  (jdk-tools/middleware project))

--- a/src/leiningen/javadoc.clj
+++ b/src/leiningen/javadoc.clj
@@ -1,6 +1,20 @@
 (ns leiningen.javadoc
-  (:require [leiningen.core.eval :as lein-core]
-            [clojure.string :as str]))
+  (:require [leiningen.core.main :refer [abort]]
+            [leiningen.core.classpath :as lein-cp]
+            [clojure.string :as str]
+            [clojure.java.io :as io]
+            [clojure.java.shell :as sh]))
+
+;;;; Obviate lein-jdk-tools
+
+(defn tools-jar
+  "Yield the canonical path to the JDK tools.jar file, or nil if not found."
+  []
+  (let [tj (io/file (System/getProperty "java.home") ".." "lib" "tools.jar")]
+    (when (.exists (io/file tj))
+      (.getCanonicalPath tj))))
+
+;;;; lein-javadoc
 
 (defn get-javadoc-opts
   "Create the map of javadoc options, using defaults where possible."
@@ -10,7 +24,8 @@
      :java-source-paths (get project :java-source-paths)
      :package-names (get javadoc-opts :package-names)
      :additional-args (get javadoc-opts :additional-args)
-     :exact-command-line (get javadoc-opts :exact-command-line)}))
+     :exact-command-line (get javadoc-opts :exact-command-line)
+     :tools-jar-paths (get javadoc-opts :tools-jar-paths)}))
 
 (defn check-options
   "Check the javadoc options and print a few diagnostics/warnings. Returns true
@@ -24,24 +39,58 @@
       (println "lein javadoc error: Required configuration key `:package-names` is empty or missing."))
     (not (or missing-package-names?))))
 
+(defn opts->args
+  [javadoc-opts]
+  (or (:exact-command-line javadoc-opts)
+      (concat ["-d"
+               (:output-dir javadoc-opts)
+               "-sourcepath"
+               (str/join ":"
+                         (:java-source-paths javadoc-opts))
+               "-subpackages"
+               (str/join ":"
+                         (:package-names javadoc-opts))]
+              (:additional-args javadoc-opts))))
+
+(defn tools-classpath
+  "Construct a tools.jar-containing classpath coll or die trying."
+  [javadoc-opts]
+  (if-let [paths (not-empty (:tools-jar-paths javadoc-opts))]
+    (if (string? paths)
+      (abort ":javadoc-opts :tools-jar-paths must be a collection of strings, not a single string. (May also be empty or nil.)")
+      paths)
+    (or [(tools-jar)]
+        (abort "No tools.jar found in system or specified in project, cannot run javadoc."))))
+
+(defn make-classpath
+  [project javadoc-opts]
+  (concat
+   (lein-cp/get-classpath project)
+   (tools-classpath javadoc-opts)))
+
+(defn run-javadoc
+  [sh-args]
+  (let [pb (.inheritIO (ProcessBuilder. (into-array String sh-args)))
+        p (try
+            (.start pb)
+            (catch java.io.IOException e
+              (abort (str "Failed to find " (first sh-args)
+                          " command.\n"
+                          (.getMessage e)))))]
+    (.waitFor p)
+    (let [exit (.exitValue p)]
+      (when (pos? exit)
+        (abort (str "javadoc exited with exit code " exit))))))
+
 (defn javadoc
   "Run javadoc"
   [project & args]
-  (let [javadoc-opts (get-javadoc-opts project)
-        arg-list (-> (or (:exact-command-line javadoc-opts)
-                         (concat ["-d"
-                                  (:output-dir javadoc-opts)
-                                  "-sourcepath"
-                                  (str/join ":"
-                                            (:java-source-paths javadoc-opts))
-                                  "-subpackages"
-                                  (str/join ":"
-                                            (:package-names javadoc-opts))]
-                                 (:additional-args javadoc-opts)))
-                     vec)]
-    (if (check-options javadoc-opts)
-      (lein-core/eval-in-project
-       project
-       `(do
-          (Main/execute (into-array String ~arg-list)))
-       `(import '[com.sun.tools.javadoc ~'Main])))))
+  (let [javadoc-opts (get-javadoc-opts project)]
+    (when (check-options javadoc-opts)
+      (let [jd-args (opts->args javadoc-opts)
+            cp (make-classpath project javadoc-opts)
+            sh-args (list* "java"
+                           "-cp" (str/join \: cp)
+                           "com.sun.tools.javadoc.Main"
+                           jd-args)]
+        (run-javadoc sh-args)))))


### PR DESCRIPTION
This fixes #1 by not including tools.jar as a dependency.

You can test it out by using `[org.clojars.brightcove/lein-javadoc "0.2.0"]`, a temporary fork release.

Sorry if this is a bit sloppy; let me know if there's cleanup I should do first.
