### PR TITLE
Allow use of alternative JDK.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changes
+
+## (pending)
+
+- Feature: Allow use of alternative JDKs.
+    - Add `:java-cmd` option to specify Java command, with `JAVA_CMD`
+      environment variable as fallback
+    - Add `:jdk-home` for autodetection of tools.jar and java binary
+      in alternative JDK
+
+## 0.2.0: 2015-05-03
+
+- Feature: Add `:tools-jar-paths` option to specify location of
+  tools.jar; otherwise fall back on auto-locating it.
+- Bugfix: Exclude tools.jar from output by shelling out instead of
+  including as dependency.
+- Dependencies: Removed lein-jdk-tools.
+
+## 0.1.1: 2013-04-20
+
+- Bugfix (attempted): Bump lein-jdk-tools dep version to exclude
+  tools.jar from jar output. (Did not succeed, see 0.2.0.)
+
+## 0.1.0: 2013-03-28
+
+- Initial version, supporting `:package-names`, `:output-dir`,
+  `:java-source-paths`, `:additional-args`, and `:exact-command-line`

--- a/README.md
+++ b/README.md
@@ -42,9 +42,21 @@ if you prefer). The map can have the following keys:
   also be warned, to head off potential frustration. This option
   exists as a safety valve, in case this task does not currently
   support some combination of configuration options you really need.
+- `:jdk-home`: This key is a string indicating the path to the JDK
+  home, used for determining the location of the `java` command and
+  tools.jar. This should include the `jre` directory, as in
+  `"/usr/lib/jvm/jdk-8-oracle-x64/jre"`.
+- `:java-cmd`: This key is a string indicating the path to the `java`
+  command. If not supplied, defaults to these in order:
+    - `../bin/java` relative to `:jdk-home`, if present;
+    - value of `JAVA_CMD` in the environment;
+    - the constant `java`.
 - `:tools-jar-paths`: This key is a vector of strings pointing to
-  possible locations of tools.jar. If empty or missing, lein-javadoc
-  will attempt to locate tools.jar by looking in java.home.
+  possible locations of tools.jar. If empty or missing, defaults to
+  these in order:
+    - `../lib/tools.jar` relative to `:jdk-home`, if present;
+    - `../lib/tools.jar` relative to current JVM's `java.home`
+      property.
 
 Also note that you must have the JDK installed for this task to work,
 as Javadoc is a part of the JDK's lib/tools.jar. This plugin should
@@ -55,7 +67,16 @@ Once the plugin is configured for your project, you can invoke the
 directory.
 
     $ lein javadoc
-    
+
+To use an alternative JDK, use `JAVA_CMD` with lein:
+
+    $ JAVA_CMD=/usr/lib/jvm/java-1.7.0-openjdk-amd64/bin/java lein javadoc
+
+By default this will have the effect of using both the java binary and
+the tools.jar from the specified JDK. (In other uses, be sure to align
+the source of the java binary and the source of tools.jar to ensure
+compatibility.)
+
 ## Development
 
 If you want to hack on this code, note that it does not currently work

--- a/src/leiningen/javadoc.clj
+++ b/src/leiningen/javadoc.clj
@@ -5,14 +5,35 @@
             [clojure.java.io :as io]
             [clojure.java.shell :as sh]))
 
+(defn getenv
+  "Wrap System/getenv(String) for testing."
+  [k]
+  (System/getenv k))
+
+(defn getprop
+  "Wrap System/getProperty for testing."
+  ([k] (System/getProperty k))
+  ([k d] (System/getProperty k d)))
+
 ;;;; Obviate lein-jdk-tools
+
+(defn canonical-path
+  "Given a set of path components, yield the canonical path, or nil if
+not found."
+  [path-parts]
+  (let [f (apply io/file path-parts)]
+    (when (.exists (io/file f))
+      (.getCanonicalPath f))))
 
 (defn tools-jar
   "Yield the canonical path to the JDK tools.jar file, or nil if not found."
-  []
-  (let [tj (io/file (System/getProperty "java.home") ".." "lib" "tools.jar")]
-    (when (.exists (io/file tj))
-      (.getCanonicalPath tj))))
+  [jdk-home-path]
+  (canonical-path [jdk-home-path ".." "lib" "tools.jar"]))
+
+(defn java-bin
+  "Yield the canonical path to the java binary, or nil if not found."
+  [jdk-home-path]
+  (canonical-path [jdk-home-path ".." "bin" "java"]))
 
 ;;;; lein-javadoc
 
@@ -25,6 +46,8 @@
      :package-names (get javadoc-opts :package-names)
      :additional-args (get javadoc-opts :additional-args)
      :exact-command-line (get javadoc-opts :exact-command-line)
+     :jdk-home (get javadoc-opts :jdk-home)
+     :java-cmd (get javadoc-opts :java-cmd)
      :tools-jar-paths (get javadoc-opts :tools-jar-paths)}))
 
 (defn check-options
@@ -52,6 +75,15 @@
                          (:package-names javadoc-opts))]
               (:additional-args javadoc-opts))))
 
+(defn java-cmd-path
+  "Determine a path for shelling out to java."
+  [javadoc-opts]
+  (or (:java-cmd javadoc-opts)
+      (when-let [jh (:jdk-home javadoc-opts)]
+        (java-bin jh))
+      (getenv "JAVA_CMD")
+      "java"))
+
 (defn tools-classpath
   "Construct a tools.jar-containing classpath coll or die trying."
   [javadoc-opts]
@@ -59,8 +91,10 @@
     (if (string? paths)
       (abort ":javadoc-opts :tools-jar-paths must be a collection of strings, not a single string. (May also be empty or nil.)")
       paths)
-    (or [(tools-jar)]
-        (abort "No tools.jar found in system or specified in project, cannot run javadoc."))))
+    [(or (when-let [jh (:jdk-home javadoc-opts)]
+           (tools-jar jh))
+         (tools-jar (getprop "java.home"))
+         (abort "No tools.jar found in system or specified in project, cannot run javadoc."))]))
 
 (defn make-classpath
   [project javadoc-opts]
@@ -89,7 +123,8 @@
     (when (check-options javadoc-opts)
       (let [jd-args (opts->args javadoc-opts)
             cp (make-classpath project javadoc-opts)
-            sh-args (list* "java"
+            java-cmd (java-cmd-path javadoc-opts)
+            sh-args (list* java-cmd
                            "-cp" (str/join \: cp)
                            "com.sun.tools.javadoc.Main"
                            jd-args)]

--- a/test/leiningen/t_javadoc.clj
+++ b/test/leiningen/t_javadoc.clj
@@ -56,6 +56,6 @@
   (with-redefs [jd/tools-jar (constantly nil)]
     (with-redefs [leiningen.core.main/abort #(throw (Exception. %))]
       (is (thrown-with-msg? Exception #"must be a collection of strings"
-                            (= (jd/tools-classpath {:tools-jar-paths "foo"})))))
-    (is (thrown-with-msg? Exception #"No tools[.]jar found"
-                          (= (jd/tools-classpath {}))))))
+                            (jd/tools-classpath {:tools-jar-paths "foo"})))
+      (is (thrown-with-msg? Exception #"No tools[.]jar found"
+                            (jd/tools-classpath {}))))))

--- a/test/leiningen/t_javadoc.clj
+++ b/test/leiningen/t_javadoc.clj
@@ -59,3 +59,37 @@
                             (jd/tools-classpath {:tools-jar-paths "foo"})))
       (is (thrown-with-msg? Exception #"No tools[.]jar found"
                             (jd/tools-classpath {}))))))
+
+(deftest get-javadoc-opts
+  (testing "empty -- defaulting"
+    (is (= (jd/get-javadoc-opts {:javadoc-opts {}})
+           (jd/get-javadoc-opts {})
+           {:output-dir "javadoc/"
+            :java-source-paths nil
+            :package-names nil
+            :additional-args nil
+            :exact-command-line nil
+            :jdk-home nil
+            :java-cmd nil
+            :tools-jar-paths nil})))
+  (testing "full + unrecognized"
+    (is (= (jd/get-javadoc-opts {:java-source-paths ["jsp"]
+                                 :javadoc-opts
+                                 {:output-dir "od"
+                                  :package-names ["pn"]
+                                  :additional-args ["aa"]
+                                  :exact-command-line ["ecl"]
+                                  :jdk-home "jh"
+                                  :java-cmd "jc"
+                                  :tools-jar-paths ["tjp"]
+                                  ;; confirm that unrecognized things
+                                  ;; are not included
+                                  :bogus-extra "be"}})
+           {:output-dir "od"
+            :java-source-paths ["jsp"]
+            :package-names ["pn"]
+            :additional-args ["aa"]
+            :exact-command-line ["ecl"]
+            :jdk-home "jh"
+            :java-cmd "jc"
+            :tools-jar-paths ["tjp"]}))))

--- a/test/leiningen/t_javadoc.clj
+++ b/test/leiningen/t_javadoc.clj
@@ -1,0 +1,61 @@
+(ns leiningen.t-javadoc
+  (:require [leiningen.javadoc :as jd]
+            [clojure.test :refer :all]
+            [clojure.string :as str]))
+
+(deftest java-cmd-fallbacks
+  ;; Command from option; JDK home from option (and whether tools.jar
+  ;; is found there); JAVA_CMD from environment; expected output.
+  (are [opt-cmd opt-home home-exists? env    output]
+       (= (with-redefs [jd/getenv #(if (= %& ["JAVA_CMD"])
+                                     env
+                                     "UNEXPECTED")
+                        jd/canonical-path #(when home-exists?
+                                             (str/join "/" %))]
+            (jd/java-cmd-path {:java-cmd opt-cmd
+                               :jdk-home opt-home}))
+          output)
+       ;; Prefer :java-cmd
+       "comj"   "HOME"    true        "envj" "comj"
+       ;; Fall back to :jdk-home
+       nil     "HOME"    true         "envj" "HOME/../bin/java"
+       ;; Fall back to JAVA_CMD
+       nil     "HOME"    false        "envj" "envj"
+       nil     nil       nil          "envj" "envj"
+       ;; Finally fall back to constant "java"
+       nil     nil       nil          nil    "java"))
+
+(deftest tools-jar-fallbacks
+  ;; Paths from option; JDK home from option (and whether tools.jar is
+  ;; found there); same for JDK home detected from current JVM;
+  ;; expected output.
+  (are [opt-paths opt-home opt-home? prop-home prop-home? output]
+       (= (with-redefs
+            [jd/getprop #(if (= %& ["java.home"])
+                           prop-home
+                           "UNEXPECTED")
+             jd/canonical-path (fn [parts]
+                                 (when (nil? (first parts))
+                                   (throw "Unexpected nil for jdk home"))
+                                 (when (or (and (= (first parts) opt-home)
+                                                opt-home?)
+                                           (and (= (first parts) prop-home)
+                                                prop-home?))
+                                   (str/join "/" parts)))]
+            (jd/tools-classpath {:tools-jar-paths opt-paths
+                                 :jdk-home opt-home}))
+          output)
+       ;; Prefer :tools-jar-paths
+       ["opath"]  "OHOME"  true      "PHOME"   true ["opath"]
+       ;; Fall back to :jdk-home
+       []         "OHOME"  true      "PHOME"   true ["OHOME/../lib/tools.jar"]
+       nil        "OHOME"  true      "PHOME"   true ["OHOME/../lib/tools.jar"]
+       ;; Fall back to current JVM
+       nil        "OHOME"  false     "PHOME"   true ["PHOME/../lib/tools.jar"]
+       nil        nil      nil       "PHOME"   true ["PHOME/../lib/tools.jar"])
+  (with-redefs [jd/tools-jar (constantly nil)]
+    (with-redefs [leiningen.core.main/abort #(throw (Exception. %))]
+      (is (thrown-with-msg? Exception #"must be a collection of strings"
+                            (= (jd/tools-classpath {:tools-jar-paths "foo"})))))
+    (is (thrown-with-msg? Exception #"No tools[.]jar found"
+                          (= (jd/tools-classpath {}))))))


### PR DESCRIPTION
- Introduces :jdk-home and :java-cmd options
- Allows finding tools.jar in other JDK
- Allows finding java binary in explicit command, other JDK, or
  JAVA_CMD environment variable
